### PR TITLE
Fallback to dev versioning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.millipede</groupId>
     <artifactId>osgi-config-extension-feature</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.0-SNAPSHOT</version>
 
     <packaging>feature</packaging>
 


### PR DESCRIPTION
It seems the Gitlab maven repository does not handle release versions in the way it should be. Further investigation is necessary.